### PR TITLE
bug(backend): fixed empty user register and login bug

### DIFF
--- a/backend/controller/auth.controller.ts
+++ b/backend/controller/auth.controller.ts
@@ -4,6 +4,7 @@ import { Request, Response } from "express";
 import send from "../utils/response/index.js";
 import { pool } from '../db/config.js';
 import jwt from 'jsonwebtoken';
+import { isVailedEmail, isVailedPassword, isVailedUsername } from '../utils/validators/index.js';
 
 interface userData {
     name: string;
@@ -15,6 +16,12 @@ export const Login = async (req: Request, res: Response) => {
 
     try {
         const { email, password } = req.body;
+
+        const isEmailVailed = isVailedEmail(email);
+
+        if (!isEmailVailed) {
+            return send.badRequest(res, "Invailed credentials");
+        }
 
         // checks if user exists
         const [exists, fields]: any = await pool.query('SELECT id, name, profile_image, password FROM users WHERE email = ?', [email]);
@@ -62,6 +69,23 @@ export const Register = async (req: Request, res: Response) => {
 
     try {
         const { name, email, password } = req.body;
+
+        const isEmailVailed = isVailedEmail(email);
+        const isPasswordVailed = isVailedPassword(password);
+        const isUsernameVailed = isVailedUsername(name);
+
+        if (!isUsernameVailed) {
+            return send.badRequest(res, "Username should not be less than 4 characters");
+        }
+
+        if (!isEmailVailed) {
+            return send.badRequest(res, "Please enter vailed email");
+        }
+
+        if (!isPasswordVailed) {
+            return send.badRequest(res, "Password length must be atleast 8 characters");
+        }
+
         const saltRounds: number = typeof (process.env.SALTROUNDS) == "string" && parseInt(process.env.SALTROUNDS) || 10;// adds salt rounds
         // checks if user exists 
         const [exists, fields]: any = await pool.query('SELECT email FROM users WHERE email = ?', [email]);

--- a/backend/utils/validators/authValidators.ts
+++ b/backend/utils/validators/authValidators.ts
@@ -1,0 +1,52 @@
+/**
+ * Checks if a given email is vailed or not
+ * @param string - The string to check for vailed email
+ * @returns True if the string is vailed email, false if email is invailed
+ * @example
+ * // Returns true
+ * isVailedEmail("prateek@prateekyadu.com")
+ * 
+ * // Returns false  
+ * isVailedEmail("not_vailed_email")
+ */
+
+export const isVailedEmail = (email: string) => {
+    const regexEmailFormat = /^[a-z0-9]+@+[a-z0-9]+[.]+([a-z]{2,})+$/;
+    return regexEmailFormat.test(email);
+};
+
+
+/**
+ * Checks if a given password is vailed or not
+ * @param string - The string to check for vailed password
+ * @returns True if the password is vailed, false if password is invailed
+ * @example
+ * // Returns true
+ * isVailedEmail("TheGoodPassword@413")
+ * 
+ * // Returns false  
+ * isVailedEmail("passwd")
+ */
+
+export const isVailedPassword = (password: string) => {
+    const regexPasswordFormat = /^.{8,}$/; // minimum length of password is 8
+    return regexPasswordFormat.test(password);
+};
+
+
+/**
+ * Checks if a given username is vailed or not
+ * @param string - The string to check for vailed username
+ * @returns True if the username is vailed, false if username is invailed
+ * @example
+ * // Returns true
+ * isVailedEmail("Prateek Yadu")
+ * 
+ * // Returns false  
+ * isVailedEmail("pky")
+ */
+
+export const isVailedUsername = (username: string) => {
+    const regexUsernameFormat = /^([^0-9]+[a-zA-z ]{3,})$/; // minimum length of username is 4
+    return regexUsernameFormat.test(username);
+};

--- a/backend/utils/validators/index.ts
+++ b/backend/utils/validators/index.ts
@@ -1,3 +1,4 @@
 import { validateVMName } from "./vmValidators.js";
+import { isVailedEmail, isVailedPassword, isVailedUsername } from "./authValidators.js";
 
-export { validateVMName };
+export { validateVMName, isVailedEmail, isVailedPassword, isVailedUsername };


### PR DESCRIPTION
## What this PR does

- closes issue #34 
- registering or logging empty user will now throw an error
- added email, password, username validators
- password should be atleast of 8 characters long
- username should be like `Prateek Yadu` or `Prateek` it should not contain any number and must be 4 character long
- unacceptable username example `Prateek-Yadu` and `Prateek 07`