### PR TITLE
feat(frontend/backend): implement subscribed plans page

### DIFF
--- a/backend/controller/me.controller.ts
+++ b/backend/controller/me.controller.ts
@@ -83,3 +83,38 @@ export const subscribedPlans = async (req: customRequest, res: Response) => {
         send.internalError(res);
     }
 };
+
+export const RenewSubscribedPlan = async (req: Request, res: Response) => {
+
+    try {
+        const id = req.params.id;
+
+        const [plan]: any = await pool.query("SELECT id, expires_at FROM user_plans WHERE id=?", [id]);
+
+        const expires_at = plan[0]?.expires_at;
+
+        // check if plan exists
+        if (plan.length > 0) {
+
+            // chekck if plan is expired 
+            const isPlanExpired: boolean = isExpired(expires_at);
+
+            if (isPlanExpired) {
+                // add 28 more from current date
+                const [update_plan] = await pool.query("UPDATE user_plans SET purchased_at=current_timestamp(), expires_at=(SELECT DATE_ADD((SELECT NOW()), INTERVAL ? DAY)) WHERE id=?", [28, id]); // 28 days of plan renew extension is hard coded
+
+                send.ok(res, "Plan renewed successfully");
+            } else {
+                // extend 28 days from expiration date
+                const [update_plan] = await pool.query("UPDATE user_plans SET expires_at=(SELECT DATE_ADD(?, INTERVAL ? DAY)) WHERE id=?;", [expires_at, 28, id]);
+
+                send.ok(res, "Plan renewed successfully");
+            }
+        } else {
+            send.notFound(res, "Subscription not found");
+        }
+
+    } catch (error) {
+        send.internalError(res);
+    }
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -273,23 +273,27 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -401,9 +405,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -436,10 +440,11 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -707,40 +712,39 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -804,12 +808,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -968,22 +972,6 @@
         "node": ">= 8.0"
       }
     },
-    "node_modules/mysql2/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/named-placeholders": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
@@ -1070,9 +1058,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1094,18 +1082,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/router": {

--- a/backend/routes/profile/profile.routes.ts
+++ b/backend/routes/profile/profile.routes.ts
@@ -1,6 +1,5 @@
 import { Router } from "express";
-import { me, subscribedPlans } from "../../controller/me.controller.js";
-import { authMiddleware } from "../../middleware/auth.middleware.js";
+import { me, RenewSubscribedPlan, subscribedPlans } from "../../controller/me.controller.js";
 
 const router = Router();
 
@@ -8,5 +7,8 @@ router.get("/me", me);
 
 // user subscribed plans 
 router.get("/me/plans", subscribedPlans);
+
+// renew user subscribed plan 
+router.post("/me/plans/:id/renew", RenewSubscribedPlan);
 
 export default router;

--- a/frontend/src/pages/dashboard/billings/Billings.tsx
+++ b/frontend/src/pages/dashboard/billings/Billings.tsx
@@ -1,0 +1,129 @@
+import { Filter } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+
+interface UserPlan {
+    id: string;
+    in_use: number;
+    purchased_at: string;
+    expires_at: string;
+    name: string;
+    vCPU: number;
+    storage: number;
+    backups: number;
+    memory: number;
+}
+
+export default function Billing() {
+
+    const [plans, setPlans] = useState<UserPlan[] | null>(null);
+
+    const getAllPlans = async () => {
+        const res = await (await fetch("/api/v1/profile/me/plans")).json();
+
+        if (res.status == 200) {
+            setPlans(res.data);
+        }
+
+        if (res.status == 500) {
+            toast.error(res.message);
+        }
+
+
+    };
+
+    const renewPlan = async (id: string) => {
+        const res = await (await fetch(`/api/v1/profile/me/plans/${id}/renew`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        })).json();
+
+        if (res.status == 200) {
+            toast.success(res.message);
+        } else {
+            toast.error(res.message);
+        }
+    };
+
+    // returns formated date eg. March 18, 2026
+    const formatDate = (d: string) => {
+
+        const givenDate = new Date(d);
+        const date = givenDate.getDate().toString();
+        const month = givenDate.toLocaleDateString('default', { month: "long" }); // gets month name eg. march
+        const year = givenDate.getFullYear();
+        return `${month + " " + date + ", " + year}`;
+    };
+
+    useEffect(() => {
+        getAllPlans();
+    }, []);
+
+
+
+    return (
+        <>
+            {/* Header */}
+            <div className="flex items-center justify-between mt-4 mb-8">
+                <h3 className="scroll-m-20 text-xl lg:text-2xl font-semibold tracking-tight text-primary">
+                    Subscriptions
+                </h3>
+                <button className="flex items-center gap-2 bg-white border border-border-primary py-2 text-secondary-foreground hover:text-primary px-4 rounded text-sm font-medium hover:bg-accent/[2%] cursor-pointer" onClick={() => {
+                }}> <Filter className="size-5 hidden lg:flex" />Filter</button>
+            </div>
+
+            {/* Table */}
+            <div className="w-full bg-white border-[1px] border-border-primary mt-8 rounded-xl">
+                {/* table head  */}
+                <div className="grid xl:grid-cols-4 grid-cols-1 px-8">
+                    <div className="flex items-center justify-center xl:justify-start gap-2 py-4">
+                        <span className="text-sm font-semibold text-accent ">Subscriptions</span>
+                    </div>
+                    <div className="hidden xl:flex items-center justify-center gap-2 py-4">
+                        <span className="text-sm font-semibold text-accent ">Purchase date</span>
+                    </div>
+                    <div className="hidden xl:flex items-center justify-center gap-2 py-4">
+                        <span className="text-sm font-semibold text-accent ">Expiration date</span>
+                    </div>
+                </div>
+                {/* Table body */}
+
+                {/* subscription Box */}
+                {plans?.map((plan: UserPlan) => (
+                    <div className="px-8 py-6 grid xl:grid-cols-4 border-t-[1px] border-border-primary text-sm" key={plan.id}>
+
+                        {/* grid 1 - Plan name */}
+                        <div className="flex gap-x-4 grid-rows-2 items-center">
+                            <h4 className="scroll-m-20 text-lg font-semibold tracking-tight text-accent wrap-anywhere">{plan.name}</h4>
+
+                            <div className={plan.in_use === 1 ? "flex" : " hidden"}>
+                                <p className="col-end-3 text-muted flex items-center gap-3 text-xs font-medium"> <span className="bg-primary-background text-primary/80 font-medium ring-1 ring-border-primary rounded-full text-xs px-2 py-1 xl:hidden 2xl:flex">in use</span></p>
+                            </div>
+                        </div>
+
+                        {/* grid 2 - Purchased at */}
+                        <div className="hidden xl:flex items-center justify-center text-primary gap-3">
+                            {formatDate(plan.purchased_at)}
+                        </div>
+
+                        {/* grid 3 - Expires at  */}
+                        <div className="hidden xl:flex items-center justify-center text-primary gap-2">
+                            {formatDate(plan.expires_at)}
+                        </div>
+
+                        {/* grid 4 - Renew plan button */}
+                        <div className="flex items-center justify-end gap-6 relative">
+                            <button className="text-accent px-4 py-2 ring-1 rounded ring-accent text-sm font-medium hover:bg-accent hover:text-white transition-all duration-300 cursor-pointer w-full xl:w-fit mt-6 xl:mt-0" onClick={() => {
+                                renewPlan(plan.id);
+                            }}>Renew</button>
+                        </div>
+                    </div>
+                ))}
+
+            </div>
+        </>
+    );
+}

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -12,6 +12,7 @@ import AuthProvider from "../components/Providers/AuthProvider";
 import { Provider } from "react-redux";
 import { store } from "../app/store";
 import Pricing from "../pages/Pricing";
+import Billing from "../pages/dashboard/billings/Billings";
 
 
 export default function AppRoutes() {
@@ -30,7 +31,8 @@ export default function AppRoutes() {
                         {
                             path: "dashboard", Component: DashboardLayout, children: [
                                 { index: true, Component: Dashboard },
-                                { path: "vps", Component: VPS }
+                                { path: "vps", Component: VPS },
+                                { path: "billing", Component: Billing }
                             ]
                         }
                     ]


### PR DESCRIPTION
## What this PR does

- closes issue #46 
- added plan renew route in backend
- plan can be renewed from API route POST `/api/v1/profile/me/plans/:id/renew`
- added fronted page to list user purchased plans and renew plan