### PR TITLE
feat(backend): added log support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 backend/node_modules
+backend/logs
 backend/dist
 backend/.env

--- a/backend/controller/auth.controller.ts
+++ b/backend/controller/auth.controller.ts
@@ -5,11 +5,16 @@ import send from "../utils/response/index.js";
 import { pool } from '../db/config.js';
 import jwt from 'jsonwebtoken';
 import { isVailedEmail, isVailedPassword, isVailedUsername } from '../utils/validators/index.js';
+import { logger } from '../utils/logger/logger.utils.js';
 
 interface userData {
     name: string;
     email: string;
     profileImage: string;
+}
+
+interface customRequest extends Request {
+    id?: string;
 }
 
 export const Login = async (req: Request, res: Response) => {
@@ -20,13 +25,20 @@ export const Login = async (req: Request, res: Response) => {
         const isEmailVailed = isVailedEmail(email);
 
         if (!isEmailVailed) {
+
+            logger.log("auth", { ip: req.ip, message: `[validator]: Failed email check`, type: "error", route: "POST /login" });
             return send.badRequest(res, "Invailed credentials");
         }
 
         // checks if user exists
         const [exists, fields]: any = await pool.query('SELECT id, name, profile_image, password FROM users WHERE email = ?', [email]);
 
+
         if (exists.length != 0) {
+
+            // stores user id
+            const userId = exists[0].id;
+
             // checks password is vailed or not
             const vailed = await bcrypt.compare(password, exists[0].password);
 
@@ -52,15 +64,23 @@ export const Login = async (req: Request, res: Response) => {
                     secure: process.env.IN_PROD == "true" && true || false
                 });
 
+                logger.log("auth", { ip: req.ip, message: "Successfull user login", type: "success", userId: userId, route: "POST /login" });
+
                 // sends response
                 send.ok(res, "User Authenticated Successfully", { ...userInfo });
             } else {
+
+                logger.log("auth", { ip: req.ip, message: `Failed login attempt`, type: "error", userId: userId, route: "POST /login" });
                 send.unauthorized(res, "Invailed Credentials");
             }
         } else {
+
+            logger.log("auth", { ip: req.ip, message: `Login attempt from invailed email address ${email}`, type: "error", route: "POST /login" });
             send.unauthorized(res, "Invailed Credentials");
         }
     } catch (error) {
+
+        logger.log("auth", { ip: req.ip, message: `Internal Error`, type: "error", route: "POST /login" });
         send.internalError(res);
     }
 };
@@ -76,6 +96,7 @@ export const Logout = async (req: Request, res: Response) => {
             send.ok(res, "User already logged out");
         }
     } catch (error) {
+        logger.log("auth", { ip: req.ip, message: `Internal Error`, type: "error", route: "POST /logout" });
         send.internalError(res);
     }
 };
@@ -90,14 +111,17 @@ export const Register = async (req: Request, res: Response) => {
         const isUsernameVailed = isVailedUsername(name);
 
         if (!isUsernameVailed) {
+            logger.log("auth", { ip: req.ip, message: `[validator]: Failed username check`, type: "error", route: "POST /register" });
             return send.badRequest(res, "Username should not be less than 4 characters");
         }
 
         if (!isEmailVailed) {
+            logger.log("auth", { ip: req.ip, message: `[validator]: Failed email check`, type: "error", route: "POST /register" });
             return send.badRequest(res, "Please enter vailed email");
         }
 
         if (!isPasswordVailed) {
+            logger.log("auth", { ip: req.ip, message: `[validator]: Failed password check`, type: "error", route: "POST /register" });
             return send.badRequest(res, "Password length must be atleast 8 characters");
         }
 
@@ -106,6 +130,9 @@ export const Register = async (req: Request, res: Response) => {
         const [exists, fields]: any = await pool.query('SELECT email FROM users WHERE email = ?', [email]);
 
         if (exists.length != 0) {
+
+            logger.log("auth", { ip: req.ip, message: `User already exists with email ${email}`, type: "error", route: "POST /register" });
+
             // return duplicate user error
             send.conflict(res, "User Already Exists");
         } else {
@@ -117,13 +144,16 @@ export const Register = async (req: Request, res: Response) => {
             const values = [userId, name, email, hash];
             const [result, fields] = await pool.execute(sql, values);
 
+            logger.log("auth", { ip: req.ip, message: `User Created successfully with email address ${email}`, type: "success", route: "POST /register" });
             send.created(res, "User Created Successfuly");
         }
     } catch (error) {
+        logger.log("auth", { ip: req.ip, message: `Internal server error`, type: "error", route: "POST /register" });
         send.internalError(res);
     }
 };
 
-export const Validate = async (req: Request, res: Response) => {
+export const Validate = async (req: customRequest, res: Response) => {
+    logger.log("auth", { ip: req.ip, message: `Hit success`, type: "success", route: "POST /validate", userId: req.id });
     send.ok(res); // sends ok if middleware validates the token 
 };

--- a/backend/controller/me.controller.ts
+++ b/backend/controller/me.controller.ts
@@ -2,6 +2,7 @@ import { pool } from "../db/config.js";
 import send from "../utils/response/response.js";
 import { Request, Response } from "express";
 import { isExpired } from "../utils/validators/planValidators.js";
+import { logger } from "../utils/logger/logger.utils.js";
 
 interface customRequest extends Request {
     id?: string;
@@ -22,6 +23,7 @@ export const me = async (req: customRequest, res: Response) => {
             send.notFound(res, "User Not Found");
         }
     } catch (error) {
+        logger.log("profile", { ip: req.ip, message: `Internal error`, type: "error", route: "GET /me" });
         send.internalError(res);
     }
 };
@@ -80,11 +82,12 @@ export const subscribedPlans = async (req: customRequest, res: Response) => {
             send.notFound(res, "You are not subscribed to any plan.");
         }
     } catch (error) {
+        logger.log("profile", { ip: req.ip, message: `Internal error`, type: "error", route: "GET /me/plans" });
         send.internalError(res);
     }
 };
 
-export const RenewSubscribedPlan = async (req: Request, res: Response) => {
+export const RenewSubscribedPlan = async (req: customRequest, res: Response) => {
 
     try {
         const id = req.params.id;
@@ -103,18 +106,25 @@ export const RenewSubscribedPlan = async (req: Request, res: Response) => {
                 // add 28 more from current date
                 const [update_plan] = await pool.query("UPDATE user_plans SET purchased_at=current_timestamp(), expires_at=(SELECT DATE_ADD((SELECT NOW()), INTERVAL ? DAY)) WHERE id=?", [28, id]); // 28 days of plan renew extension is hard coded
 
+                logger.log("billing", { ip: req.ip, message: `Plan renewed successfully`, type: "success", route: "POST /me/plans/:id/renew", userId: req.id });
                 send.ok(res, "Plan renewed successfully");
             } else {
                 // extend 28 days from expiration date
                 const [update_plan] = await pool.query("UPDATE user_plans SET expires_at=(SELECT DATE_ADD(?, INTERVAL ? DAY)) WHERE id=?;", [expires_at, 28, id]);
 
+
+                logger.log("billing", { ip: req.ip, message: `Plan renewed successfully`, type: "success", route: "POST /me/plans/:id/renew", userId: req.id });
+
                 send.ok(res, "Plan renewed successfully");
             }
         } else {
+
+            logger.log("billing", { ip: req.ip, message: `Trying to renew non-existing plan`, type: "error", route: "POST /me/plans/:id/renew", userId: req.id });
             send.notFound(res, "Subscription not found");
         }
 
     } catch (error) {
+        logger.log("profile", { ip: req.ip, message: `Internal error`, type: "error", route: "POST /me/plans/:id/renew" });
         send.internalError(res);
     }
 };

--- a/backend/controller/plans.controller.ts
+++ b/backend/controller/plans.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import send from "../utils/response/response.js";
 import { pool } from "../db/config.js";
 import { v4 as uuidv4 } from 'uuid';
+import { logger } from "../utils/logger/logger.utils.js";
 
 interface customRequest extends Request {
     id?: string;
@@ -16,6 +17,7 @@ export const Plans = async (req: Request, res: Response) => {
         send.ok(res, "", plans);
 
     } catch (error) {
+        logger.log("billing", { ip: req.ip, message: `Internal server error`, type: "error", route: "GET /plans" });
         send.internalError(res);
     }
 };
@@ -34,12 +36,16 @@ export const purchasePlan = async (req: customRequest, res: Response) => {
 
             const [userPlan, fields]: any = await pool.query("INSERT INTO user_plans (id, user_id, plan_id, expires_at) VALUES (?, ?, ?, (SELECT DATE_ADD((SELECT NOW()), INTERVAL ? DAY)))", [userPlanTableId, userId, planId, planValidity]);
 
+            logger.log("billing", { ip: req.ip, message: `Plan purchased successfully`, type: "success", route: "POST /:id/purchase", userId: req.id });
             send.ok(res, "Plan Purchased Successfully.");
         } else {
+
+            logger.log("billing", { ip: req.ip, message: `Trying to Purchase non-existing plan`, type: "error", route: "POST /:id/purchase", userId: req.id });
             send.notFound(res, "Plan Not Found.");
         }
 
     } catch (error) {
+        logger.log("billing", { ip: req.ip, message: `Internal server error`, type: "error", route: "POST /:id/purchase" });
         send.internalError(res);
     }
 

--- a/backend/controller/vms.controller.ts
+++ b/backend/controller/vms.controller.ts
@@ -3,6 +3,7 @@ import send from "../utils/response/response.js";
 import { pool } from "../db/config.js";
 import { v4 as uuidv4 } from 'uuid';
 import { validateVMName } from "../utils/validators/index.js";
+import { logger } from "../utils/logger/logger.utils.js";
 
 
 // TODO: Put every thing in try catch block
@@ -66,6 +67,9 @@ export const allVMs = async (req: customRequest, res: Response) => {
       send.notFound(res, "No VM Found.");
     }
   } catch (error) {
+
+    logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "GET /vms" });
+
     send.internalError(res);
   }
 };
@@ -103,6 +107,9 @@ export const getVM = async (req: customRequest, res: Response) => {
       send.notFound(res, "VM not found by this name.");
     }
   } catch (error) {
+
+    logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "GET /vms/:vmId" });
+
     send.internalError(res);
   }
 };
@@ -115,10 +122,17 @@ export const createVM = async (req: customRequest, res: Response) => {
     const isVailedVMName = validateVMName(vmName); // checks if VM Name is vailed (eg, db01.prateek.inc, staging-server-prateek-labs)or not 
 
     if (!isVailedVMName) {
+
+      logger.log("instance", { ip: req.ip, message: `[validator]: Failed vm name check`, type: "error", route: "POST /vms", userId: req.id });
+
       send.badRequest(res, "Enter vailed VM Name"); // sends error is VM name is not vailed
     } else {
 
-      if (rootPassword == undefined || rootPassword.length <= 0) { // cheks root password exists 
+      if (rootPassword == undefined || rootPassword.length <= 0) {
+
+        logger.log("instance", { ip: req.ip, message: `[validator]: Failed vm password check`, type: "error", route: "POST /vms", userId: req.id });
+
+        // cheks root password exists 
         send.badRequest(res, "Enter Root Password");
         return;
       }
@@ -137,11 +151,17 @@ export const createVM = async (req: customRequest, res: Response) => {
 
         // check if plan is expired
         if (expired) {
+
+          logger.log("instance", { ip: req.ip, message: `User trying to create VM with expired plan`, type: "error", route: "POST /vms", userId: req.id });
+
           send.forbidden(res, "Plan Expired.");
         } else {
 
           // check if plan in use
           if (inUse) {
+
+            logger.log("instance", { ip: req.ip, message: `User trying to create VM with plan already in use`, type: "error", route: "POST /vms", userId: req.id });
+
             send.forbidden(res, "Instance is already initialized with this plan.");
           } else {
             // generates VM's ID (stored as name in LXC/LXD and ID in DB)
@@ -152,6 +172,9 @@ export const createVM = async (req: customRequest, res: Response) => {
 
             // sends conflict error if vm name is already thier 
             if (vmExists.length != 0) {
+
+              logger.log("instance", { ip: req.ip, message: `VM already initialized with given name`, type: "error", route: "POST /vms", userId: req.id });
+
               send.conflict(res, "VM already exists with this name");
               return;
             }
@@ -164,6 +187,9 @@ export const createVM = async (req: customRequest, res: Response) => {
 
             // cheks if IP exists to assign to VM
             if (assignableIP == undefined) {
+
+              logger.log("instance", { ip: req.ip, message: `Failed to create VM due to no assignable IP available`, type: "error", route: "POST /vms" });
+
               send.internalError(res); // No assignable IP Found
             } else {
 
@@ -196,8 +222,13 @@ export const createVM = async (req: customRequest, res: Response) => {
 
                 const [instance, instanceFields]: any = await pool.query('INSERT INTO instances (id, name, description, status, image_id, address_id, user_id, user_plan_id, region_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)', [vmID, vmName, vmDescription, "Provisioning", 1, ip[0].id, userId, planId, 1]);
 
+                logger.log("instance", { ip: req.ip, message: `VM created successfully`, type: "success", route: "POST /vms", userId: req.id });
+
                 send.ok(res, "VM Created Successfully");
               } else {
+
+                logger.log("instance", { ip: req.ip, message: `VM creation failed`, type: "error", route: "POST /vms", userId: req.id });
+
                 // error coz VM creation might have failed
                 send.internalError(res);
               }
@@ -205,10 +236,16 @@ export const createVM = async (req: customRequest, res: Response) => {
           }
         }
       } else {
+
+        logger.log("instance", { ip: req.ip, message: `VM creation failed because plan not vailed`, type: "error", route: "POST /vms", userId: req.id });
+
         send.notFound(res, "Plan does not exist.");
       }
     }
   } catch (error) {
+
+    logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "POST /vms" });
+
     send.internalError(res);
   }
 };
@@ -234,6 +271,9 @@ export const startVM = async (req: customRequest, res: Response) => {
 
       // cheks if plan is expired
       if (expired) {
+
+        logger.log("instance", { ip: req.ip, message: `Can not perform any action plan expired`, type: "error", route: "PUT /vms/:vmId/start", userId: req.id, vmId: vmId });
+
         send.forbidden(res, "Can not perform any action plan expired.");
       } else {
 
@@ -253,6 +293,9 @@ export const startVM = async (req: customRequest, res: Response) => {
         }
 
         if (VMstatusInLXD === "Running") {
+
+          logger.log("instance", { ip: req.ip, message: `Can not start, VM already running`, type: "info", route: "PUT /vms/:vmId/start", userId: req.id, vmId: vmId });
+
           send.badRequest(res, "VM is already Running.");
         } else {
           const vmStartReq: any = await (await fetch(`${process.env.LXD_AGENT_SERVER}/api/v1/instance/${vmId}/start`, {
@@ -263,16 +306,27 @@ export const startVM = async (req: customRequest, res: Response) => {
             // update state in DB
             const [updateState]: any = await pool.query('UPDATE instances SET status=? WHERE id=?', ["Running", vmId]);
 
+            logger.log("instance", { ip: req.ip, message: `VM Started`, type: "info", route: "PUT /vms/:vmId/start", userId: req.id, vmId: vmId });
+
             send.ok(res, "VM started successfully");
           } else {
+
+            logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "PUT /vms/:vmId/start" });
+            
             send.internalError(res);
           }
         }
       }
     } else {
+
+      logger.log("instance", { ip: req.ip, message: `No VM Found by the name ${vmName}`, type: "info", route: "PUT /vms/:vmId/start", userId: req.id });
+
       send.notFound(res, "VM not found");
     }
   } catch (error) {
+
+    logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "POST /vms" });
+
     send.internalError(res);
   }
 };
@@ -298,6 +352,9 @@ export const stoptVM = async (req: customRequest, res: Response) => {
 
       // cheks if plan is expired
       if (expired) {
+
+        logger.log("instance", { ip: req.ip, message: `Can not perform any action plan expired`, type: "error", route: "PUT /vms/:vmId/stop", userId: req.id, vmId: vmId });
+
         send.forbidden(res, "Can not perform any action plan expired.");
       } else {
 
@@ -317,6 +374,9 @@ export const stoptVM = async (req: customRequest, res: Response) => {
         }
 
         if (VMstatusInLXD === "Stopped") {
+
+          logger.log("instance", { ip: req.ip, message: `Can not stop VM, already Stopped`, type: "info", route: "PUT /vms/:vmId/stop", userId: req.id, vmId: vmId });
+
           send.badRequest(res, "VM is already Stopped.");
         } else {
           const vmStopReq: any = await (await fetch(`${process.env.LXD_AGENT_SERVER}/api/v1/instance/${vmId}/stop`, {
@@ -327,16 +387,27 @@ export const stoptVM = async (req: customRequest, res: Response) => {
             // update state in DB
             const [updateState]: any = await pool.query('UPDATE instances SET status=? WHERE id=?', ["Stopped", vmId]);
 
+            logger.log("instance", { ip: req.ip, message: `VM Stopped successfully`, type: "info", route: "PUT /vms/:vmId/stop", userId: req.id, vmId: vmId });
+
             send.ok(res, "VM Stopped successfully.");
           } else {
+
+            logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "PUT /vms/:vmId/stop" });
+
             send.internalError(res);
           }
         }
       }
     } else {
+
+      logger.log("instance", { ip: req.ip, message: `Vm not found by name ${vmName}`, type: "info", route: "PUT /vms/:vmId/stop", userId: req.id });
+
       send.notFound(res, "VM not found");
     }
   } catch (error) {
+
+    logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "PUT /vms/:vmId/stop" });
+
     send.internalError(res);
   }
 };
@@ -361,9 +432,15 @@ export const restartVM = async (req: customRequest, res: Response) => {
 
       // cheks if plan is expired
       if (expired) {
+
+        logger.log("instance", { ip: req.ip, message: `Can not perform any action plan expired`, type: "error", route: "PUT /vms/:vmId/restart", userId: req.id, vmId: vmId });
+
         send.forbidden(res, "Can not perform any action plan expired.");
       } else {
         if (vmStatus === "Stopped") {
+
+          logger.log("instance", { ip: req.ip, message: `Cannot restart VM, VM not running`, type: "info", route: "PUT /vms/:vmId/restart", userId: req.id, vmId: vmId });
+
           send.badRequest(res, "VM is not Running.");
         } else {
           const vmRestartReq: any = await (await fetch(`${process.env.LXD_AGENT_SERVER}/api/v1/instance/${vmId}/restart`, {
@@ -371,16 +448,28 @@ export const restartVM = async (req: customRequest, res: Response) => {
           })).json();
 
           if (vmRestartReq.status === 200) {
+
+            logger.log("instance", { ip: req.ip, message: `Restarting VM`, type: "info", route: "PUT /vms/:vmId/restart", userId: req.id, vmId: vmId });
+
             send.ok(res, "VM is restarting.");
           } else {
+
+            logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "PUT /vms/:vmId/restart" });
+
             send.internalError(res);
           }
         }
       }
     } else {
+
+      logger.log("instance", { ip: req.ip, message: `VM not found by the name ${vmName}`, type: "error", route: "PUT /vms/:vmId/restart", userId: req.id });
+
       send.notFound(res, "VM not found");
     }
   } catch (error) {
+
+    logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "PUT /vms/:vmId/restart" });
+
     send.internalError(res);
   }
 };
@@ -407,6 +496,9 @@ export const destroyVM = async (req: customRequest, res: Response) => {
 
       // cheks if plan is expired
       if (expired) {
+
+        logger.log("instance", { ip: req.ip, message: `Can not perform any action plan expired.`, type: "error", route: "DELETE /vms/:vmId", userId: req.id, vmId: vmId });
+
         send.forbidden(res, "Can not perform any action plan expired.");
       } else {
 
@@ -426,6 +518,9 @@ export const destroyVM = async (req: customRequest, res: Response) => {
         }
 
         if (VMstatusInLXD !== "Stopped") {
+
+          logger.log("instance", { ip: req.ip, message: `Cannot destroy VM while running, Stop VM`, type: "info", route: "DELETE /vms/:vmId", userId: req.id, vmId: vmId });
+
           send.badRequest(res, "Stop the VM first");
         } else {
 
@@ -448,17 +543,28 @@ export const destroyVM = async (req: customRequest, res: Response) => {
             // release reserved IP
             const [releaseIP]: any = await pool.query('UPDATE ip_addresses SET in_use=0 WHERE id=?', [vmIPId]);
 
+            logger.log("instance", { ip: req.ip, message: `VM deleted`, type: "info", route: "DELETE /vms/:vmId", userId: req.id, vmId: vmId });
+
             send.ok(res, "VM deleted successfully.");
           } else {
+
+            logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "DELETE /vms/:vmId" });
+
             send.internalError(res);
           }
         }
       }
 
     } else {
+
+      logger.log("instance", { ip: req.ip, message: `VM not found by the name ${vmName}`, type: "error", route: "DELETE /vms/:vmId" });
+
       send.notFound(res, "VM not found");
     }
   } catch (error) {
+
+    logger.log("instance", { ip: req.ip, message: `Internal error`, type: "error", route: "DELETE /vms/:vmId" });
+
     send.internalError(res);
   }
 

--- a/backend/utils/logger/logger.utils.ts
+++ b/backend/utils/logger/logger.utils.ts
@@ -8,11 +8,10 @@ interface log {
     userId?: string;
     ip: string | undefined;
     route: string;
-
 }
 
 export const logger = {
-    async log(filename: "auth" | "billing" | "instance", log: log) {
+    async log(filename: "auth" | "billing" | "instance" | "profile", log: log) {
 
         log.timestamp = Date.now();
 

--- a/backend/utils/logger/logger.utils.ts
+++ b/backend/utils/logger/logger.utils.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+
+interface log {
+    timestamp?: number;
+    type: "success" | "error" | "info",
+    message: string,
+    vmId?: string,
+    userId?: string;
+    ip: string | undefined;
+    route: string;
+
+}
+
+export const logger = {
+    async log(filename: "auth" | "billing" | "instance", log: log) {
+
+        log.timestamp = Date.now();
+
+        // creates logs folder if dir does not exists
+        if (!fs.existsSync("./logs")) {
+            fs.mkdirSync("./logs");
+        }
+
+        fs.appendFile(`./logs/${filename}.log`, JSON.stringify(log) + "\n", err => { });
+
+    }
+};


### PR DESCRIPTION
## What this PR does

- Closes issue #54.
- Added logger util function.
- Logging is implemented for backend only.
- Logs will be stored at `/backend/logs` folder.
- Logs are divided into 3 files  :-
`auth`: For authentication related logs.
`billing`: For billing related logs.
`instance`: For instance related logs.

#### Log Structure 

```json
// For Billing, Auth logs
{
  "timestamp": "",
  "type": "success | error | info",
  "message": "",
  "userId": ""
}

// For instance related logs
{
  "timestamp": "",
  "type": "success | error | info",
  "message": "",
  "vmId": "",
  "userId": ""
}
```