### PR TITLE
feat: added log support workers agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ backend/node_modules
 backend/logs
 backend/dist
 backend/.env
+
+# Logs
+
+logs

--- a/__deploy__/loki/config.alloy
+++ b/__deploy__/loki/config.alloy
@@ -5,7 +5,15 @@ livedebugging {
 }
 
 local.file_match "local_files" {
-    path_targets = [{"__path__" = "/temp/logs/*.log", "job" = "backend", "hostname" = constants.hostname}]
+    path_targets = [
+      {"__path__" = "/temp/logs/backend/*.log", "job" = "backend", "service" = "backend", "hostname" = constants.hostname},
+      {"__path__" = "/temp/logs/workers/event/*.log", "job" = "event-worker", "service" = "worker", "hostname" = constants.hostname},
+      {"__path__" = "/temp/logs/workers/expiry/*.log", "job" = "expiry-worker", "service" = "worker", "hostname" = constants.hostname},
+      {"__path__" = "/temp/logs/workers/lifecycle/*.log", "job" = "lifecycle-worker", "service" = "worker", "hostname" = constants.hostname},
+      {"__path__" = "/temp/logs/workers/provision/*.log", "job" = "provision-worker", "service" = "worker", "hostname" = constants.hostname},
+      {"__path__" = "/temp/logs/workers/sync/*.log", "job" = "sync-worker", "service" = "worker", "hostname" = constants.hostname},
+      {"__path__" = "/temp/logs/lxd_agent/*.log", "job" = "lxd-agent", "service" = "lxd-agent", "hostname" = constants.hostname},
+      ]
     sync_period  = "5s"
 }
  

--- a/backend/lib/logger.utils.ts
+++ b/backend/lib/logger.utils.ts
@@ -26,7 +26,7 @@ export const logger = {
             const __filename = fileURLToPath(import.meta.url)
             const __dirname = dirname(__filename)
 
-            const outDir = path.join(__dirname, "..", "logs")
+            const outDir = path.join(__dirname, "..", "..", "logs", "backend")
             
             log.timestamp = Date.now();
     

--- a/backend/lib/logger.utils.ts
+++ b/backend/lib/logger.utils.ts
@@ -12,6 +12,13 @@ interface log {
     route: string;
 }
 
+interface workerLog {
+    timestamp?: number;
+    type: "success" | "error" | "info" ,
+    message: string,
+    error?: string
+}
+
 export const logger = {
     async log(filename: "auth" | "billing" | "instance" | "profile", log: log) {
 
@@ -34,5 +41,30 @@ export const logger = {
         }
 
 
+    }, worker: {
+        async log(worker: "event" | "expiry" | "lifecycle" | "provision" | "sync", log: workerLog){
+            try {
+                const __filename = fileURLToPath(import.meta.url)
+                const __dirname = dirname(__filename)
+
+                const outDir = path.join(__dirname, "..", "..", "logs", "workers", worker)
+
+                log.timestamp = Date.now();
+
+                if(!fs.existsSync(outDir)) {
+                    fs.mkdirSync(outDir, {
+                        recursive: true
+                    })
+                }
+
+                fs.appendFile(`${outDir}/${worker}.worker.log`, JSON.stringify(log) + "\n", (err:any) =>{
+                    if(err){
+                        throw new Error(err)
+                    }
+                })
+            }catch (error: any){
+                throw new Error("ERROR: Failed to wite log reason: ", error)
+            }
+        }
     }
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,9 +8,9 @@
   "main": "app.ts",
   "scripts": {
     "dev": "node --watch --loader ts-node/esm --no-warnings=ExperimentalWarning server/app.ts",
-    "event-worker": "node --watch workers/event.worker.ts",
-    "lifecycle-worker": "node --watch workers/lifecycle.worker.ts",
-    "provision-worker": "node --watch workers/provision.worker.ts",
+    "event-worker": "tsx watch workers/event.worker.ts",
+    "lifecycle-worker": "tsx watch workers/lifecycle.worker.ts",
+    "provision-worker": "tsx watch workers/provision.worker.ts",
     "sync-worker": "tsx watch workers/sync.worker.ts",
     "expiry-worker": "tsx watch workers/expiry.worker.ts"
   },

--- a/backend/server/controller/auth.controller.ts
+++ b/backend/server/controller/auth.controller.ts
@@ -232,7 +232,7 @@ export const Validate = async (req: customRequest, res: Response) => {
   logger.log("auth", {
     ip: req.ip,
     message: `Hit success`,
-    type: "success",
+    type: "info",
     route: "POST /validate",
     userId: req.id,
   });

--- a/backend/workers/event.worker.ts
+++ b/backend/workers/event.worker.ts
@@ -1,7 +1,7 @@
 import { config } from "dotenv";
 import { Redis } from "ioredis";
-// @ts-ignore
-import { pool } from "../lib/db.ts";
+import { pool } from "../lib/db.js";
+import { logger } from "../lib/logger.utils.js";
 
 // dotenv config
 config({ path: "../.env" });
@@ -14,9 +14,12 @@ const redis = new Redis();
 
 var iscrashed = false;
 
-socket.addEventListener("open", () => {
+socket.addEventListener("open", async () => {
   iscrashed = false;
-  console.log("listening for socket connection...");
+  await logger.worker.log("event", {
+    type: "info",
+    message: "Listening for socket connection...",
+  });
 });
 
 socket.addEventListener("message", async (event) => {
@@ -57,16 +60,25 @@ socket.addEventListener("message", async (event) => {
       );
     }
   } catch (error) {
-    // logs error - # TODO
+    await logger.worker.log("event", {
+      type: "error",
+      message: "Error while performing operation.",
+    });
   }
 });
 
-socket.addEventListener("error", () => {
-  // logs error - # TODO
+socket.addEventListener("error", async (error) => {
+  await logger.worker.log("event", {
+    type: "error",
+    message: "Socket connection error.",
+  });
 });
 
-socket.addEventListener("close", () => {
-  console.log("connection closed by server");
+socket.addEventListener("close", async () => {
+  await logger.worker.log("event", {
+    type: "error",
+    message: "Socket connection closed by server.",
+  });
   iscrashed = true;
 });
 

--- a/backend/workers/expiry.worker.ts
+++ b/backend/workers/expiry.worker.ts
@@ -1,11 +1,11 @@
-import {Redis} from "ioredis";
+import { Redis } from "ioredis";
 import { pool } from "../lib/db.js";
 import { lifecycleQueue } from "../server/queues/instance/lifecycle.queue.js";
 import { isExpired } from "../server/utils/validators/planValidators.js";
 import { redisConnection } from "../lib/redis.js";
+import { logger } from "../lib/logger.utils.js";
 
 const redis = new Redis(redisConnection.connection);
-
 
 const getExpiredHrs = (expiredDate: Date) => {
   const currentDate = new Date();
@@ -30,13 +30,20 @@ const getExpiredInstance = async () => {
     for (const instance of instnaces) {
       const expired: boolean = isExpired(instance.expires_at);
       if (expired) {
+        await logger.worker.log("expiry", {
+          type: "info",
+          message: `Found expired instance ${instance.id}.`,
+        });
         expiredInstnaceList.push(instance);
       }
     }
 
     return expiredInstnaceList;
   } catch (error) {
-    throw new Error("Can not get expired instances");
+    await logger.worker.log("expiry", {
+      type: "error",
+      message: `Can not get expired instances.`,
+    });
   }
 };
 
@@ -49,10 +56,21 @@ const stopInstance = async (instanceId: string) => {
     );
 
     if (!(instanceStopReq.status == 200)) {
-      throw new Error("can not stop instance");
+      await logger.worker.log("expiry", {
+        type: "error",
+        message: `Can not stop expired instance, lxd agent returned ${instanceStopReq.status} status code.`,
+      });
+    } else {
+      await logger.worker.log("expiry", {
+        type: "success",
+        message: `Stopped expired instance ${instanceId}.`,
+      });
     }
   } catch (error: any) {
-    throw new Error("can not stop instance", error);
+    await logger.worker.log("expiry", {
+      type: "error",
+      message: `Error stopping expired instance.`,
+    });
   }
 };
 
@@ -80,10 +98,16 @@ const sendTODeletionQueue = async (instance: any) => {
   const queueReq = await lifecycleQueue(queueData);
 
   if (queueReq === "waiting" || queueReq === "active") {
+    await logger.worker.log("expiry", {
+      type: "info",
+      message: `Sent expired instnace ${queueData.name} to delete queue.`,
+    });
     return;
   } else {
-    // log error
-    throw new Error("Error deleting instance from redis side");
+    await logger.worker.log("expiry", {
+      type: "error",
+      message: `Error can not delete expired instance ${queueData.name}, Queue returned status ${queueReq}.`,
+    });
   }
 };
 
@@ -111,7 +135,10 @@ const expiryWorker = async () => {
     // remove expired instances in age is > 48 hrs
     await removeExpiredInstance();
   } catch (error: any) {
-    console.log("Error", error.message);
+    await logger.worker.log("expiry", {
+      type: "error",
+      message: `Error occured in worker`,
+    });
   }
 };
 

--- a/backend/workers/lifecycle.worker.ts
+++ b/backend/workers/lifecycle.worker.ts
@@ -1,10 +1,9 @@
 import { config } from "dotenv";
 import { Job, Worker } from "bullmq";
-// @ts-ignore
-import { redisConnection } from "../lib/redis.ts";
-// @ts-ignore
-import { pool } from "../lib/db.ts";
+import { redisConnection } from "../lib/redis.js";
+import { pool } from "../lib/db.js";
 import { Redis } from "ioredis";
+import { logger } from "../lib/logger.utils.js";
 
 config({ path: "../.env" });
 
@@ -69,12 +68,21 @@ const worker = new Worker(
             }
 
             if (instanceOperationReq.status !== 200) {
-              throw new Error("Operation failed");
+              await logger.worker.log("lifecycle", {
+                type: "error",
+                message: `Can not perform operation ${job.data.operation} to instance ${job.data.name}, Operation failed.`,
+              });
+            } else {
+              await logger.worker.log("lifecycle", {
+                type: "error",
+                message: `Successfully performed ${job.data.operation} operation to instance ${job.data.name}.`,
+              });
             }
           } else {
-            throw new Error(
-              `Instance not present to perform ${job.data.operation} operation`,
-            );
+            await logger.worker.log("lifecycle", {
+              type: "error",
+              message: `Instance ${job.data.name} not present to perform ${job.data.operation} operation.`,
+            });
           }
 
           break;
@@ -111,6 +119,11 @@ const worker = new Worker(
               "UPDATE ip_addresses SET in_use=0 WHERE id=?",
               [job.data.instanceIPID],
             );
+
+            await logger.worker.log("lifecycle", {
+              type: "info",
+              message: `Deleted instance ${job.data.name} from lxd & DB.`,
+            });
           } else {
             // --- ignore when retry
 
@@ -138,27 +151,33 @@ const worker = new Worker(
             }
 
             // ---
-
-            throw new Error(
-              "delete operation success, retrying for database clean up",
-            );
           }
 
           break;
       }
     } catch (error: any) {
-      throw new Error("Instance operation failed, Reason:", error);
+      await logger.worker.log("lifecycle", {
+        type: "error",
+        message: `Can not perform ${job.data.operation} operation to instance ${job.data.name}.`,
+      });
     }
   },
   redisConnection,
 );
 
-worker.on("ready", () => {
+worker.on("ready", async () => {
+  await logger.worker.log("lifecycle", {
+    type: "info",
+    message: "Worker is up and running.",
+  });
   iscrashed = false;
 });
 
-worker.on("error", () => {
-  console.log("DOWN");
+worker.on("error", async () => {
+  await logger.worker.log("lifecycle", {
+    type: "error",
+    message: "Worker went down.",
+  });
   iscrashed = true;
 });
 

--- a/backend/workers/provision.worker.ts
+++ b/backend/workers/provision.worker.ts
@@ -1,8 +1,8 @@
 import { config } from "dotenv";
 import { Job, Worker } from "bullmq";
-// @ts-ignore
-import { redisConnection } from "../lib/redis.ts";
+import { redisConnection } from "../lib/redis.js";
 import { Redis } from "ioredis";
+import { logger } from "../lib/logger.utils.js";
 
 config({ path: "../.env" });
 
@@ -27,21 +27,39 @@ const worker = new Worker(
       ).json();
 
       if (createInstance.status !== 200) {
-        throw new Error("Instance creation failed");
+        await logger.worker.log("provision", {
+          type: "error",
+          message: `Instnace ${job.data.name} provision failed.`,
+        });
+      } else {
+        await logger.worker.log("provision", {
+          type: "success",
+          message: `Instnace ${job.data.name} provisioned successfully.`,
+        });
       }
     } catch (error: any) {
-      throw new Error("Instance creation failed, Reason:", error);
+      await logger.worker.log("provision", {
+        type: "error",
+        message: `Instance ${job.data.name} provision failed.`,
+      });
     }
   },
   redisConnection,
 );
 
-worker.on("ready", () => {
+worker.on("ready", async () => {
+  await logger.worker.log("provision", {
+    type: "info",
+    message: "Worker is up and running.",
+  });
   iscrashed = false;
 });
 
-worker.on("error", () => {
-  console.log("DOWN");
+worker.on("error", async () => {
+  await logger.worker.log("provision", {
+    type: "error",
+    message: "Worker went down.",
+  });
   iscrashed = true;
 });
 

--- a/backend/workers/sync.worker.ts
+++ b/backend/workers/sync.worker.ts
@@ -3,6 +3,7 @@ import { pool } from "../lib/db.js";
 import { lifecycleQueue } from "../server/queues/instance/lifecycle.queue.js";
 import { Redis } from "ioredis";
 import { redisConnection } from "../lib/redis.js";
+import { logger } from "../lib/logger.utils.js";
 
 config({ path: "../.env" });
 
@@ -36,11 +37,17 @@ const instnaceFromServer = async () => {
       }
       return instances;
     } else {
-      // log error
-      console.log("Something went wrong");
+      await logger.worker.log("sync", {
+        type: "error",
+        message: "Failed to fetch instance list from lxd agent.",
+      });
     }
   } catch (error) {
-    throw new Error("failed to fetch instance list from server");
+    await logger.worker.log("sync", {
+      type: "error",
+      message:
+        "Something went wrong while featching instance list from lxd agent.",
+    });
   }
 };
 
@@ -59,7 +66,11 @@ const instnaceFromDB = async () => {
     }
     return instances;
   } catch (error) {
-    throw new Error("failed to fetch instance list from database");
+    await logger.worker.log("sync", {
+      type: "error",
+      message:
+        "Something went wrong while featching instance list from database.",
+    });
   }
 };
 
@@ -82,12 +93,22 @@ const sendTODeletionQueue = async (instance: any) => {
     const queueReq = await lifecycleQueue(queueData);
 
     if (queueReq === "waiting" || queueReq === "active") {
+      await logger.worker.log("sync", {
+        type: "info",
+        message: `Sended instance ${queueData.name} to delete queue.`,
+      });
       return;
     } else {
-      throw new Error("Error deleting instance");
+      await logger.worker.log("sync", {
+        type: "error",
+        message: `Error can not delete instance ${queueData.name}, Queue returned status ${queueReq}.`,
+      });
     }
   } catch (error) {
-    throw new Error("Error deleting instance");
+    await logger.worker.log("sync", {
+      type: "error",
+      message: `Error sending instance ${instance.id} to delete queue.`,
+    });
   }
 };
 
@@ -109,6 +130,11 @@ const syncState = async (dbList: any, serverList: any) => {
           "UPDATE instances SET status=? WHERE id=?",
           [statusInServer, instance[0]],
         );
+
+        await logger.worker.log("lifecycle", {
+          type: "info",
+          message: `Synced instnace ${instance[0]} status.`,
+        });
       }
     } else {
       // executes when records does not exists on server
@@ -132,6 +158,13 @@ const stopInstance = async (instanceId: string) => {
       { method: "PUT" },
     )
   ).json();
+
+  if (instanceOperationReq === 200) {
+    await logger.worker.log("sync", {
+      type: "success",
+      message: "Instance stopped successfully.",
+    });
+  }
 };
 
 const deleteInstance = async (instance: any) => {
@@ -149,19 +182,25 @@ const deleteInstance = async (instance: any) => {
       ).json();
 
       if (instanceDeletetionReq.status !== 200) {
-        throw new Error("LXD can not create operation");
+        await logger.worker.log("sync", {
+          type: "error",
+          message: `Can not delete ghost instance ${instance.name}, recived ${instanceDeletetionReq.status} status from lxd agent.`,
+        });
       } else {
-        // logo deleted instance
-        console.log(`deleted instance: ${instance.name}`);
+        await logger.worker.log("sync", {
+          type: "success",
+          message: `Ghost instance ${instance.name} delete successfully.`,
+        });
       }
     } else {
       // stop instance -> will be deleted next time worker runs
       await stopInstance(instance.name);
     }
   } catch (error: any) {
-    // log error
-    console.log(error);
-    console.log("can not delete instance");
+    await logger.worker.log("sync", {
+      type: "error",
+      message: `Can not delete gohst instance ${instance.name}.`,
+    });
   }
 };
 
@@ -180,7 +219,10 @@ const removeGhost = async (dbList: any, serverList: any) => {
       }
     }
   } catch (error) {
-    throw new Error("error removing ghost instance");
+    await logger.worker.log("sync", {
+      type: "error",
+      message: "Error removing ghost instance.",
+    });
   }
 };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - 4318:4318
     volumes:
       - ./__deploy__/loki/config.alloy:/etc/alloy/config.alloy
-      - ./backend/logs:/temp/logs
+      - ./logs:/temp/logs
     command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental  --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
       - logs_collector

--- a/lxd_agent/controller/instance.controller.ts
+++ b/lxd_agent/controller/instance.controller.ts
@@ -1,206 +1,359 @@
 import { Request, Response } from "express";
 import send from "../utils/response/index.js";
+import { logger } from "../utils/logger/logger.utils.js";
 
 export const createInstance = async (req: Request, res: Response) => {
+  try {
+    const { id, rootPassword, ipAddress, vCPU, memory, storage } = req.body;
 
-    try {
-        const { id, rootPassword, ipAddress, vCPU, memory, storage } = req.body;
+    if (
+      id === undefined ||
+      rootPassword === undefined ||
+      ipAddress === undefined ||
+      vCPU === undefined ||
+      memory === undefined ||
+      storage === undefined
+    ) {
+      logger.log({
+        ip: req.ip,
+        message: `[validator]: Failed validation check.`,
+        type: "error",
+        route: "POST /instnace",
+      });
+      send.badRequest(res);
+    } else {
+      // creates new instance
+      const lxdResponse: any = await (
+        await fetch(
+          `${process.env.LXD_SERVER}/1.0/instances?project=${process.env.PROJECT}`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              name: `${id}`,
+              config: {
+                "cloud-init.network-config": `network:\n  version: 2\n  ethernets:\n    enp5s0:\n      dhcp4: false\n      addresses:\n        - ${ipAddress}/24\n      gateway4: 10.10.10.1\n      nameservers:\n        addresses: [10.10.10.1,8.8.8.8]\n\n`,
+                "cloud-init.user-data": `#cloud-config\nchpasswd:\n  expire: false\n  users:\n  - {name: root, password: ${rootPassword}, type: text}\nssh_pwauth: true\ndisable_root: true\nruncmd:\n  - echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/custom-cloud-init.conf\n  - systemctl restart ssh`,
+                "limits.cpu": `${vCPU}`,
+                "limits.memory": `${memory}GiB`,
+              },
+              devices: {
+                root: {
+                  path: "/",
+                  pool: `${process.env.LXD_STORAGE_POOL}`,
+                  type: `${process.env.LXD_STORAGE_POOL_TYPE}`,
+                  size: `${storage}GiB`,
+                },
+              },
+              source: {
+                alias: "24.04",
+                protocol: "simplestreams",
+                server: "https://cloud-images.ubuntu.com/releases/",
+                type: "image",
+              },
+              "boot.autostart": false,
+              start: true,
+              type: "virtual-machine",
+            }),
+          },
+        )
+      ).json();
 
-        if (id === undefined || rootPassword === undefined || ipAddress === undefined || vCPU === undefined || memory === undefined || storage === undefined) {
-            send.badRequest(res);
-        } else {
-
-            // creates new instance
-            const lxdResponse: any = await (await fetch(`${process.env.LXD_SERVER}/1.0/instances?project=${process.env.PROJECT}`, {
-                method: "POST",
-                body: JSON.stringify({
-                    "name": `${id}`,
-                    "config": {
-                        "cloud-init.network-config": `network:\n  version: 2\n  ethernets:\n    enp5s0:\n      dhcp4: false\n      addresses:\n        - ${ipAddress}/24\n      gateway4: 10.10.10.1\n      nameservers:\n        addresses: [10.10.10.1,8.8.8.8]\n\n`,
-                        "cloud-init.user-data": `#cloud-config\nchpasswd:\n  expire: false\n  users:\n  - {name: root, password: ${rootPassword}, type: text}\nssh_pwauth: true\ndisable_root: true\nruncmd:\n  - echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/custom-cloud-init.conf\n  - systemctl restart ssh`,
-                        "limits.cpu": `${vCPU}`,
-                        "limits.memory": `${memory}GiB`
-                    },
-                    "devices": {
-                        "root": {
-                            "path": "/",
-                            "pool": `${process.env.LXD_STORAGE_POOL}`,
-                            "type": `${process.env.LXD_STORAGE_POOL_TYPE}`,
-                            "size": `${storage}GiB`
-                        }
-                    },
-                    "source": {
-                        "alias": "24.04",
-                        "protocol": "simplestreams",
-                        "server": "https://cloud-images.ubuntu.com/releases/",
-                        "type": "image"
-                    },
-                    "boot.autostart": false,
-                    "start": true,
-                    "type": "virtual-machine"
-                })
-            })).json();
-
-            if (lxdResponse.status_code === 100) {
-                send.ok(res);
-            } else {
-                send.internalError(res);
-            }
-        }
-
-
-    } catch (error) {
+      if (lxdResponse.status_code === 100) {
+        await logger.log({
+          ip: req.ip,
+          type: "success",
+          message: "Instance created successfully.",
+          route: "POST /instance",
+        });
+        send.ok(res);
+      } else {
+        await logger.log({
+          ip: req.ip,
+          type: "error",
+          message: "Failed to create instance.",
+          route: "POST /instance",
+        });
         send.internalError(res);
+      }
     }
+  } catch (error) {
+    await logger.log({
+      ip: req.ip,
+      type: "error",
+      message: "Failed to create instance.",
+      route: "POST /instance",
+    });
+    send.internalError(res);
+  }
 };
 
 export const getAllInstance = async (req: Request, res: Response) => {
+  try {
+    // get indivisual instance
+    const lxdResponse: any = await (
+      await fetch(
+        `${process.env.LXD_SERVER}/1.0/instances?project=${process.env.PROJECT}&recursion=2`,
+      )
+    ).json();
 
-    try {
-        // get indivisual instance
-        const lxdResponse: any = await (await fetch(`${process.env.LXD_SERVER}/1.0/instances?project=${process.env.PROJECT}&recursion=2`)).json();
-
-        if (lxdResponse.status_code === 200) {
-            send.ok(res, "", lxdResponse);
-        } else {
-            send.internalError(res);
-        }
-
-    } catch (error) {
-        send.internalError(res);
+    if (lxdResponse.status_code === 200) {
+      send.ok(res, "", lxdResponse);
+    } else {
+      await logger.log({
+        ip: req.ip,
+        type: "error",
+        message: "Failed to get instances.",
+        route: "GET /instance",
+      });
+      send.internalError(res);
     }
+  } catch (error) {
+    await logger.log({
+      ip: req.ip,
+      type: "error",
+      message: "Failed to get instances.",
+      route: "GET /instance",
+    });
+    send.internalError(res);
+  }
 };
 
 export const getIndivisualInstance = async (req: Request, res: Response) => {
+  try {
+    const id = req.params.vmId;
 
-    try {
-        const id = req.params.vmId;
+    if (id === undefined) {
+      send.badRequest(res);
+    } else {
+      // get indivisual instance
+      const lxdResponse: any = await (
+        await fetch(
+          `${process.env.LXD_SERVER}/1.0/instances/${id}?project=${process.env.PROJECT}&recursion=1`,
+        )
+      ).json();
 
-        if (id === undefined) {
-            send.badRequest(res);
-        } else {
-
-            // get indivisual instance
-            const lxdResponse: any = await (await fetch(`${process.env.LXD_SERVER}/1.0/instances/${id}?project=${process.env.PROJECT}&recursion=1`)).json();
-
-            if (lxdResponse.status_code === 200) {
-                send.ok(res, "", lxdResponse);
-            } else if (lxdResponse.error_code === 404) {
-                send.notFound(res);
-            } else {
-                send.internalError(res);
-            }
-        }
-
-    } catch (error) {
+      if (lxdResponse.status_code === 200) {
+        send.ok(res, "", lxdResponse);
+      } else if (lxdResponse.error_code === 404) {
+        await logger.log({
+          ip: req.ip,
+          type: "error",
+          message: `Instance ${id} does not exists.`,
+          route: "GET /instance/:id",
+        });
+        send.notFound(res);
+      } else {
+        await logger.log({
+          ip: req.ip,
+          type: "error",
+          message: `Error getting instance ${id} server responded with ${lxdResponse.status_code} code.`,
+          route: "GET /instance/:id",
+        });
         send.internalError(res);
+      }
     }
+  } catch (error) {
+    await logger.log({
+      ip: req.ip,
+      type: "error",
+      message: `Failed to get instance ${req.params.vmId}.`,
+      route: "GET /instance/:id",
+    });
+    send.internalError(res);
+  }
 };
 
 export const startInstance = async (req: Request, res: Response) => {
+  try {
+    const id = req.params.vmId;
 
-    try {
-        const id = req.params.vmId;
+    if (id === undefined) {
+      send.badRequest(res);
+    } else {
+      // start instance
+      const lxdResponse: any = await (
+        await fetch(
+          `${process.env.LXD_SERVER}/1.0/instances/${id}/state?project=${process.env.PROJECT}`,
+          {
+            method: "PUT",
+            body: JSON.stringify({ action: "start" }),
+          },
+        )
+      ).json();
 
-        if (id === undefined) {
-            send.badRequest(res);
-        } else {
-
-            // start instance
-            const lxdResponse: any = await (await fetch(`${process.env.LXD_SERVER}/1.0/instances/${id}/state?project=${process.env.PROJECT}`, {
-                method: "PUT",
-                body: JSON.stringify({ "action": "start" })
-            })).json();
-
-            if (lxdResponse.status_code === 100) {
-                send.ok(res);
-            } else {
-                send.internalError(res);
-            }
-        }
-
-    } catch (error) {
+      if (lxdResponse.status_code === 100) {
+        await logger.log({
+          ip: req.ip,
+          type: "success",
+          message: `Starting Instnace ${req.params.vmId}.`,
+          route: "PUT /instance/:id/start",
+        });
+        send.ok(res);
+      } else {
+        await logger.log({
+          ip: req.ip,
+          type: "error",
+          message: `Can not start instance, server responded with ${lxdResponse.status_code} code.`,
+          route: "PUT /instance/:id/start",
+        });
         send.internalError(res);
+      }
     }
+  } catch (error) {
+    await logger.log({
+      ip: req.ip,
+      type: "error",
+      message: `Failed to start instance ${req.params.vmId}.`,
+      route: "PUT /instance/:id/start",
+    });
+    send.internalError(res);
+  }
 };
 
 export const stopInstance = async (req: Request, res: Response) => {
+  try {
+    const id = req.params.vmId;
 
-    try {
-        const id = req.params.vmId;
+    if (id === undefined) {
+      send.badRequest(res);
+    } else {
+      // stop instance
+      const lxdResponse: any = await (
+        await fetch(
+          `${process.env.LXD_SERVER}/1.0/instances/${id}/state?project=${process.env.PROJECT}`,
+          {
+            method: "PUT",
+            body: JSON.stringify({ action: "stop", force: true }),
+          },
+        )
+      ).json();
 
-        if (id === undefined) {
-            send.badRequest(res);
-        } else {
-
-            // stop instance
-            const lxdResponse: any = await (await fetch(`${process.env.LXD_SERVER}/1.0/instances/${id}/state?project=${process.env.PROJECT}`, {
-                method: "PUT",
-                body: JSON.stringify({ "action": "stop", "force": true })
-            })).json();
-
-            if (lxdResponse.status_code === 100) {
-                send.ok(res);
-            } else {
-                send.internalError(res);
-            }
-        }
-
-    } catch (error) {
+      if (lxdResponse.status_code === 100) {
+        await logger.log({
+          ip: req.ip,
+          type: "success",
+          message: `Stopping instnace ${id}.`,
+          route: "PUT /instance/:id/stop",
+        });
+        send.ok(res);
+      } else {
+        await logger.log({
+          ip: req.ip,
+          type: "error",
+          message: `Failed to stop instance, server responded with ${lxdResponse.status_code} code.`,
+          route: "PUT /instance/:id/stop",
+        });
         send.internalError(res);
+      }
     }
+  } catch (error) {
+    await logger.log({
+      ip: req.ip,
+      type: "error",
+      message: `Failed to stop instance ${req.params.vmId}.`,
+      route: "PUT /instance/:id/stop",
+    });
+    send.internalError(res);
+  }
 };
 
 export const restartInstance = async (req: Request, res: Response) => {
+  try {
+    const id = req.params.vmId;
 
-    try {
-        const id = req.params.vmId;
+    if (id === undefined) {
+      send.badRequest(res);
+    } else {
+      // start restart instance
+      const lxdResponse: any = await (
+        await fetch(
+          `${process.env.LXD_SERVER}/1.0/instances/${id}/state?project=${process.env.PROJECT}`,
+          {
+            method: "PUT",
+            body: JSON.stringify({ action: "restart" }),
+          },
+        )
+      ).json();
 
-        if (id === undefined) {
-            send.badRequest(res);
-        } else {
-
-            // start restart instance
-            const lxdResponse: any = await (await fetch(`${process.env.LXD_SERVER}/1.0/instances/${id}/state?project=${process.env.PROJECT}`, {
-                method: "PUT",
-                body: JSON.stringify({ "action": "restart" })
-            })).json();
-
-            if (lxdResponse.status_code === 100) {
-                send.ok(res);
-            } else {
-                send.internalError(res);
-            }
-        }
-
-    } catch (error) {
+      if (lxdResponse.status_code === 100) {
+        await logger.log({
+          ip: req.ip,
+          type: "success",
+          message: `Restarting instance ${id}.`,
+          route: "PUT /instance/:id/restart",
+        });
+        send.ok(res);
+      } else {
+        await logger.log({
+          ip: req.ip,
+          type: "error",
+          message: `Failed to restart instance ${id}.`,
+          route: "PUT /instance/:id/restart",
+        });
         send.internalError(res);
+      }
     }
+  } catch (error) {
+    await logger.log({
+      ip: req.ip,
+      type: "error",
+      message: `Failed to restart instance ${req.params.vmId}.`,
+      route: "PUT /instance/:id/restart",
+    });
+    send.internalError(res);
+  }
 };
 
 export const destroyInstance = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.body;
 
-    try {
-        const { id } = req.body;
+    if (id === undefined) {
+      send.badRequest(res);
+    } else {
+      // delete request
+      const lxdResponse: any = await (
+        await fetch(
+          `${process.env.LXD_SERVER}/1.0/instances/${id}?project=${process.env.PROJECT}`,
+          {
+            method: "DELETE",
+          },
+        )
+      ).json();
 
-        if (id === undefined) {
-            send.badRequest(res);
-        } else {
-
-            // delete request
-            const lxdResponse: any = await (await fetch(`${process.env.LXD_SERVER}/1.0/instances/${id}?project=${process.env.PROJECT}`, {
-                method: "DELETE"
-            })).json();
-
-            if (lxdResponse.status_code === 100) {
-                send.ok(res);
-            } else if (lxdResponse.error_code === 404) {
-                send.notFound(res, "instance not found");
-            } else {
-                send.internalError(res);
-            }
-        }
-    } catch (error) {
+      if (lxdResponse.status_code === 100) {
+        await logger.log({
+          ip: req.ip,
+          type: "success",
+          message: `Deleting instance ${id}.`,
+          route: "DELETE /instance",
+        });
+        send.ok(res);
+      } else if (lxdResponse.error_code === 404) {
+        await logger.log({
+          ip: req.ip,
+          type: "error",
+          message: `Can not delete instance ${id}, instance not found.`,
+          route: "DELETE /instance",
+        });
+        send.notFound(res, "instance not found");
+      } else {
+        await logger.log({
+          ip: req.ip,
+          type: "error",
+          message: `Can not delete instance, server responded with ${lxdResponse.status_code} code.`,
+          route: "DELETE /instance",
+        });
         send.internalError(res);
+      }
     }
+  } catch (error) {
+    await logger.log({
+      ip: req.ip,
+      type: "error",
+      message: `Failed to delete instance ${req.body.id}.`,
+      route: "DELETE /instance",
+    });
+    send.internalError(res);
+  }
 };

--- a/lxd_agent/tsconfig.json
+++ b/lxd_agent/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"target": "esnext",
+		"sourceMap": true,
+		"outDir": "dist",
+		"strict": true,
+		"lib": ["esnext"],
+		"esModuleInterop": true
+	}
+}

--- a/lxd_agent/utils/logger/logger.utils.ts
+++ b/lxd_agent/utils/logger/logger.utils.ts
@@ -1,0 +1,44 @@
+import fs from "fs";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+interface log {
+    timestamp?: number;
+    type: "success" | "error" | "info",
+    message: string,
+    vmId?: string,
+    ip: string | undefined;
+    route: string;
+}
+
+export const logger = {
+  async log(log: log) {
+    try {
+      const filename = "lxd_agent";
+      const __filename = fileURLToPath(import.meta.url);
+      const __dirname = dirname(__filename);
+
+      const outDir = path.join(__dirname, "..", "..", "logs", filename);
+
+      log.timestamp = Date.now();
+
+      // creates logs folder if dir does not exists
+      if (!fs.existsSync(outDir)) {
+        fs.mkdirSync(outDir, {
+          recursive: true,
+        });
+      }
+
+      fs.appendFile(
+        `${outDir}/${filename}.log`,
+        JSON.stringify(log) + "\n",
+        (err: any) => {
+          if (err) {
+            throw new Error(err);
+          }
+        },
+      );
+    } catch (error: any) {
+      throw new Error("ERROR: Failed to wite log reason: ", error);
+    }
+  },
+};

--- a/lxd_agent/utils/logger/logger.utils.ts
+++ b/lxd_agent/utils/logger/logger.utils.ts
@@ -17,7 +17,7 @@ export const logger = {
       const __filename = fileURLToPath(import.meta.url);
       const __dirname = dirname(__filename);
 
-      const outDir = path.join(__dirname, "..", "..", "logs", filename);
+      const outDir = path.join(__dirname, "..", "..", "..", "logs", filename);
 
       log.timestamp = Date.now();
 


### PR DESCRIPTION
## What this PR does

- Closes issue #69.
- Created `logger.worker.log()` util function in `backend` for workers log. 
- Created logger util function for `lxd_agent`.
- Added logs support for all 5 workers and lxd agent.
- Configured logs to be stored in `logs` directory instead of `backend/logs`.
- Configured `grafana alloy` to label logs appropriately  according to the log type.
- Modified `docker-compose.yml` to change mounted volume location from `backend/logs` to `logs`.