### PR TITLE
bug(backend/workers): fixed db resouce not freeing after instance deletion

### DIFF
--- a/backend/workers/lifecycle.worker.ts
+++ b/backend/workers/lifecycle.worker.ts
@@ -73,7 +73,7 @@ const worker = new Worker(
             });
           } else {
             await logger.worker.log("lifecycle", {
-              type: "error",
+              type: "success",
               message: `Successfully performed ${job.data.operation} operation to instance ${job.data.name}.`,
             });
           }

--- a/backend/workers/lifecycle.worker.ts
+++ b/backend/workers/lifecycle.worker.ts
@@ -8,158 +8,158 @@ import { logger } from "../lib/logger.utils.js";
 config({ path: "../.env" });
 
 // new redis instance
-const redis = new Redis(redisConnection.connection);
+const redis = new Redis();
 
 var iscrashed = false;
 
 const worker = new Worker(
   process.env.REDIS_LIFECYCLE_QUEUE || "instance-lifecycle",
   async (job: Job) => {
-    try {
-      switch (job.data.operation) {
-        case "start":
-        case "stop":
-        case "restart":
-          // gets instance
-          const getInstanceInfo: any = await (
+    switch (job.data.operation) {
+      case "start":
+      case "stop":
+      case "restart":
+        // gets instance
+        const getInstanceInfo: any = await (
+          await fetch(
+            `${process.env.LXD_AGENT_SERVER}/api/v1/instance/${job.data.name}`,
+            {
+              method: "GET",
+            },
+          )
+        ).json();
+
+        // performs operation if instance exists
+        if (getInstanceInfo.status === 200) {
+          // if status is already set as operation then, skip # TODO
+          // do a req, if already in thet state skip # TODO
+
+          // req to change instance state
+          const instanceOperationReq: any = await (
             await fetch(
-              `${process.env.LXD_AGENT_SERVER}/api/v1/instance/${job.data.name}`,
-              {
-                method: "GET",
-              },
+              `${process.env.LXD_AGENT_SERVER}/api/v1/instance/${job.data.name}/${job.data.operation}`,
+              { method: "PUT" },
             )
           ).json();
 
-          // performs operation if instance exists
-          if (getInstanceInfo.status === 200) {
-            // if status is already set as operation then, skip # TODO
-            // do a req, if already in thet state skip # TODO
+          if (job.data.operation === "restart") {
+            // update status to restarting
+            const [setStatusToRestarting]: any = await pool.query(
+              "UPDATE instances SET status=? WHERE id=?",
+              ["restarting", job.data.name],
+            );
+          }
 
-            // req to change instance state
-            const instanceOperationReq: any = await (
-              await fetch(
-                `${process.env.LXD_AGENT_SERVER}/api/v1/instance/${job.data.name}/${job.data.operation}`,
-                { method: "PUT" },
-              )
-            ).json();
+          if (job.data.operation === "start") {
+            // update status to starting
+            const [setStatusToStarting]: any = await pool.query(
+              "UPDATE instances SET status=? WHERE id=?",
+              ["starting", job.data.name],
+            );
+          }
 
-            if (job.data.operation === "restart") {
-              // update status to restarting
-              const [setStatusToRestarting]: any = await pool.query(
-                "UPDATE instances SET status=? WHERE id=?",
-                ["restarting", job.data.name],
-              );
-            }
+          if (job.data.operation === "stop") {
+            // update status to stopping
+            const [setStatusToStopping]: any = await pool.query(
+              "UPDATE instances SET status=? WHERE id=?",
+              ["stopping", job.data.name],
+            );
+          }
 
-            if (job.data.operation === "start") {
-              // update status to starting
-              const [setStatusToStarting]: any = await pool.query(
-                "UPDATE instances SET status=? WHERE id=?",
-                ["starting", job.data.name],
-              );
-            }
-
-            if (job.data.operation === "stop") {
-              // update status to stopping
-              const [setStatusToStopping]: any = await pool.query(
-                "UPDATE instances SET status=? WHERE id=?",
-                ["stopping", job.data.name],
-              );
-            }
-
-            if (instanceOperationReq.status !== 200) {
-              await logger.worker.log("lifecycle", {
-                type: "error",
-                message: `Can not perform operation ${job.data.operation} to instance ${job.data.name}, Operation failed.`,
-              });
-            } else {
-              await logger.worker.log("lifecycle", {
-                type: "error",
-                message: `Successfully performed ${job.data.operation} operation to instance ${job.data.name}.`,
-              });
-            }
+          if (instanceOperationReq.status !== 200) {
+            await logger.worker.log("lifecycle", {
+              type: "error",
+              message: `Can not perform operation ${job.data.operation} to instance ${job.data.name}, Operation failed.`,
+            });
           } else {
             await logger.worker.log("lifecycle", {
               type: "error",
-              message: `Instance ${job.data.name} not present to perform ${job.data.operation} operation.`,
+              message: `Successfully performed ${job.data.operation} operation to instance ${job.data.name}.`,
             });
           }
+        } else {
+          await logger.worker.log("lifecycle", {
+            type: "error",
+            message: `Instance ${job.data.name} not present to perform ${job.data.operation} operation.`,
+          });
+        }
 
-          break;
+        break;
 
-        case "delete":
-          // gets instance
-          const getInstanceReq: any = await (
-            await fetch(
-              `${process.env.LXD_AGENT_SERVER}/api/v1/instance/${job.data.name}`,
-              {
-                method: "GET",
-              },
-            )
-          ).json();
+      case "delete":
+        // gets instance
+        const getInstanceReq: any = await (
+          await fetch(
+            `${process.env.LXD_AGENT_SERVER}/api/v1/instance/${job.data.name}`,
+            {
+              method: "GET",
+            },
+          )
+        ).json();
 
-          // handles db cleanup in instsance is not in LXD server
-          if (getInstanceReq.status === 404) {
-            // cleanup
+        // handles db cleanup in instsance is not in LXD server
+        if (getInstanceReq.status === 404) {
+          // cleanup
 
-            // delete data from instance table
-            const [deleteInstance]: any = await pool.query(
-              "DELETE FROM instances WHERE id=?",
-              [job.data.name],
-            );
+          // delete data from instance table
+          const [deleteInstance]: any = await pool.query(
+            "DELETE FROM instances WHERE id=?",
+            [job.data.name],
+          );
 
-            // release user plan from in_use
-            const [releaseUserPlan]: any = await pool.query(
-              "UPDATE user_plans SET in_use=0 WHERE id=?",
-              [job.data.planId],
-            );
+          // release user plan from in_use
+          const [releaseUserPlan]: any = await pool.query(
+            "UPDATE user_plans SET in_use=0 WHERE id=?",
+            [job.data.planId],
+          );
 
-            // release reserved IP
-            const [releaseIP]: any = await pool.query(
-              "UPDATE ip_addresses SET in_use=0 WHERE id=?",
-              [job.data.instanceIPID],
-            );
+          // release reserved IP
+          const [releaseIP]: any = await pool.query(
+            "UPDATE ip_addresses SET in_use=0 WHERE id=?",
+            [job.data.instanceIPID],
+          );
 
-            await logger.worker.log("lifecycle", {
-              type: "info",
-              message: `Deleted instance ${job.data.name} from lxd & DB.`,
-            });
-          } else {
-            // --- ignore when retry
+          await logger.worker.log("lifecycle", {
+            type: "info",
+            message: `Deleted instance ${job.data.name} from lxd & DB.`,
+          });
+        } else {
+          // --- ignore when retry
 
-            if (job.attemptsMade < 1) {
-              // send data to lxd agent to delete instance
-              const instanceDeletetionReq: any = await (
-                await fetch(`${process.env.LXD_AGENT_SERVER}/api/v1/instance`, {
-                  method: "DELETE",
-                  headers: {
-                    "Content-Type": "application/json",
-                  },
-                  body: JSON.stringify({ id: job.data.name }),
-                })
-              ).json();
+          if (job.attemptsMade < 1) {
+            // send data to lxd agent to delete instance
+            const instanceDeletetionReq: any = await (
+              await fetch(`${process.env.LXD_AGENT_SERVER}/api/v1/instance`, {
+                method: "DELETE",
+                headers: {
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ id: job.data.name }),
+              })
+            ).json();
 
-              if (instanceDeletetionReq.status !== 200) {
-                throw new Error("LXD can not create operation");
-              }
+            if (instanceDeletetionReq.status !== 200) {
+              await logger.worker.log("lifecycle", {
+                type: "error",
+                message: `Can not perform ${job.data.operation} operation to instance ${job.data.name}. LXD responded with ${instanceDeletetionReq.status} code`,
+              });
 
-              // update status to deleting
-              const [setStatusToDeleting]: any = await pool.query(
-                "UPDATE instances SET status=? WHERE id=?",
-                ["deleting", job.data.name],
-              );
+              throw new Error("LXD can not create operation.");
             }
 
-            // ---
+            // update status to deleting
+            const [setStatusToDeleting]: any = await pool.query(
+              "UPDATE instances SET status=? WHERE id=?",
+              ["deleting", job.data.name],
+            );
+
+            throw new Error("Instnace deleted successfully.");
           }
 
-          break;
-      }
-    } catch (error: any) {
-      await logger.worker.log("lifecycle", {
-        type: "error",
-        message: `Can not perform ${job.data.operation} operation to instance ${job.data.name}.`,
-      });
+          // ---
+        }
+
+        break;
     }
   },
   redisConnection,

--- a/backend/workers/provision.worker.ts
+++ b/backend/workers/provision.worker.ts
@@ -7,7 +7,7 @@ import { logger } from "../lib/logger.utils.js";
 config({ path: "../.env" });
 
 // new redis instance
-const redis = new Redis(redisConnection.connection);
+const redis = new Redis();
 
 var iscrashed = false;
 

--- a/frontend/src/pages/dashboard/VPS/VPS.tsx
+++ b/frontend/src/pages/dashboard/VPS/VPS.tsx
@@ -94,7 +94,7 @@ export default function VPS() {
 
     toast(response.message);
 
-    setRefresh(Math.floor(Math.random() * 100));
+    setRefresh(Math.random());
   };
 
   // update VM state (start, stop, restart)
@@ -153,7 +153,6 @@ export default function VPS() {
           item.name === name ? { ...item, status: "deleting" } : item,
         );
       });
-    } else {
     }
 
     setIsCollapsableOpen(!isCollapsableOpen); // closes collapsable
@@ -238,9 +237,11 @@ export default function VPS() {
   };
 
   useEffect(() => {
-    getSubscribedPlans();
     getVMs();
+    getSubscribedPlans();
+  }, [refresh]);
 
+  useEffect(() => {
     // establish socket connection
     socket.on("connect", () => {});
     socket.on("disconnect", () => {});
@@ -249,6 +250,10 @@ export default function VPS() {
       const data = JSON.parse(msg);
       let state: string;
       switch (data.operation) {
+        case "instance-created":
+          state = "provisioning";
+          break;
+
         case "instance-started":
         case "instance-restarted":
           state = "running";
@@ -286,7 +291,7 @@ export default function VPS() {
       socket.off("disconnect", () => {});
       socket.off("instance:lifecycle:events", () => {});
     };
-  }, [refresh]);
+  }, []);
 
   return (
     <div className="text-primary">


### PR DESCRIPTION
## What this PR does

- Closes issue #72.
- Removed duplicate redis configs from provision and lifecycle worker.
- Removed try catch block in `lifecycle-worker`.

#### Why bug was formed and how it was resolved

The working of lifecycle worker is that, when instance comes for deletion, it calls `lxd-agent` to delete the instance. After response `200` is received  the worker throws and error which forces worker to retry. On retry, worker checks if instance exists or not from `lxd-agent`. If Instance does not exists in `lxd server` the DB gets cleaned up. BullMQ only retries if the error is unhandled since, the catch block handles the error the worker assumes task is completed and moves on.